### PR TITLE
[2단계 - 자동차 경주 리팩터링] 페드로(류형욱) 미션 제출합니다.

### DIFF
--- a/src/main/java/racingcar/controller/GameController.java
+++ b/src/main/java/racingcar/controller/GameController.java
@@ -5,26 +5,27 @@ import java.util.List;
 import java.util.Map;
 import racingcar.model.Car;
 import racingcar.model.CarGroup;
+import racingcar.model.RacingGame;
 import racingcar.utils.NameParser;
 import racingcar.utils.InputValidator;
 import racingcar.view.InputView;
 import racingcar.view.OutputView;
 
 public class GameController {
-    private final CarGroup carGroup = new CarGroup();
-    private int moveCount;
+    private RacingGame racingGame;
 
     public void init() throws IOException {
         List<String> names;
+        int moveCount;
 
         do {
             names = readCarNames();
         } while (!isNameValid(names));
-        initCars(names);
-
         do {
             moveCount = readMoveCount();
         } while (!isMoveCountValid(moveCount));
+
+        racingGame = new RacingGame(createCarGroup(names), moveCount);
     }
 
     private List<String> readCarNames() throws IOException {
@@ -57,22 +58,23 @@ public class GameController {
         return InputView.inputMoveCount();
     }
 
-    private void initCars(List<String> carNames) {
+    private CarGroup createCarGroup(List<String> carNames) {
+        CarGroup carGroup = new CarGroup();
+
         for (String name : carNames) {
             carGroup.add(new Car(name));
         }
+        return carGroup;
     }
 
     public void play() {
         OutputView.printResultDescription();
-        for (int i = 0; i < moveCount; i++) {
-            Map<String, Integer> raceResponse = carGroup.race();
-            OutputView.printPosition(raceResponse);
-        }
+        List<Map<String, Integer>> raceResponse = racingGame.race();
+        OutputView.printPosition(raceResponse);
     }
 
     public void finish() {
-        List<String> winners = carGroup.findWinners();
+        List<String> winners = racingGame.findWinners();
         if (winners.isEmpty()) {
             OutputView.printNoWinner();
             return;

--- a/src/main/java/racingcar/controller/GameController.java
+++ b/src/main/java/racingcar/controller/GameController.java
@@ -12,26 +12,28 @@ import racingcar.view.OutputView;
 
 public class GameController {
     private final CarGroup carGroup = new CarGroup();
-    private List<String> names;
     private int moveCount;
 
     public void init() throws IOException {
-        readCarNames();
-        readMoveCount();
+        List<String> names;
+
+        do {
+            names = readCarNames();
+        } while (!isNameValid(names));
         initCars(names);
+
+        do {
+            moveCount = readMoveCount();
+        } while (!isMoveCountValid(moveCount));
     }
 
-    private void readCarNames() throws IOException {
-        boolean isValid = false;
-        while (!isValid) {
-            isValid = doReadCarNames();
-        }
+    private List<String> readCarNames() throws IOException {
+        OutputView.printlnInputName();
+        return NameParser.parse(InputView.inputNames());
     }
 
-    private boolean doReadCarNames() throws IOException {
+    private boolean isNameValid(List<String> names) {
         try {
-            OutputView.printlnInputName();
-            names = NameParser.parse(InputView.inputNames());
             InputValidator.validateCarName(names);
         } catch (IllegalArgumentException e) {
             OutputView.printException(e.getMessage());
@@ -40,23 +42,19 @@ public class GameController {
         return true;
     }
 
-    private void readMoveCount() throws IOException {
-        boolean isValid = false;
-        while (!isValid) {
-            isValid = doReadMoveCount();
-        }
-    }
-
-    private boolean doReadMoveCount() throws IOException {
+    private boolean isMoveCountValid(int moveCount) {
         try {
-            OutputView.printlnInputMoveCount();
-            moveCount = InputView.inputMoveCount();
             InputValidator.validateMoveCount(moveCount);
         } catch (IllegalArgumentException e) {
             OutputView.printException(e.getMessage());
             return false;
         }
         return true;
+    }
+
+    private int readMoveCount() throws IOException {
+        OutputView.printlnInputMoveCount();
+        return InputView.inputMoveCount();
     }
 
     private void initCars(List<String> carNames) {

--- a/src/main/java/racingcar/controller/GameController.java
+++ b/src/main/java/racingcar/controller/GameController.java
@@ -29,7 +29,6 @@ public class GameController {
     }
 
     private List<String> readCarNames() throws IOException {
-        OutputView.printlnInputName();
         return NameParser.parse(InputView.inputNames());
     }
 
@@ -54,7 +53,6 @@ public class GameController {
     }
 
     private int readMoveCount() throws IOException {
-        OutputView.printlnInputMoveCount();
         return InputView.inputMoveCount();
     }
 

--- a/src/main/java/racingcar/model/CarGroup.java
+++ b/src/main/java/racingcar/model/CarGroup.java
@@ -13,14 +13,14 @@ public class CarGroup {
         cars.add(car);
     }
 
-    public Map<String, Integer> race() {
-        Map<String, Integer> raceResponse = new HashMap<>();
+    public Map<String, Integer> playRound() {
+        Map<String, Integer> roundResponse = new HashMap<>();
         for (Car car : cars) {
             int nextPosition = car.move(RandomNumberGenerator.generate());
-            raceResponse.put(car.getName(), nextPosition);
+            roundResponse.put(car.getName(), nextPosition);
         }
 
-        return raceResponse;
+        return roundResponse;
     }
 
     public List<String> findWinners() {

--- a/src/main/java/racingcar/model/RacingGame.java
+++ b/src/main/java/racingcar/model/RacingGame.java
@@ -1,0 +1,25 @@
+package racingcar.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+public class RacingGame {
+    CarGroup cars;
+    int moveCount;
+
+    public RacingGame(CarGroup cars, int moveCount) {
+        this.cars = cars;
+        this.moveCount = moveCount;
+    }
+
+    public List<Map<String, Integer>> race() {
+        return IntStream.range(0, moveCount)
+                .mapToObj(c -> cars.playRound())
+                .toList();
+    }
+
+    public List<String> findWinners() {
+        return cars.findWinners();
+    }
+}

--- a/src/main/java/racingcar/utils/InputValidator.java
+++ b/src/main/java/racingcar/utils/InputValidator.java
@@ -3,6 +3,9 @@ package racingcar.utils;
 import java.util.List;
 
 public class InputValidator {
+    private static final int NAME_LENGTH_LIMIT = 5;
+    private static final String NAME_REGEX_PATTERN = "^[a-zA-Z]*$";
+
     private InputValidator() {
     }
 
@@ -15,7 +18,7 @@ public class InputValidator {
     }
 
     private static void validateNameLength(String name) {
-        if (name.length() > 5) {
+        if (name.length() > NAME_LENGTH_LIMIT) {
             throw new IllegalArgumentException("자동차의 이름은 5글자를 초과할 수 없습니다.");
         }
     }
@@ -31,7 +34,7 @@ public class InputValidator {
     }
 
     private static void validateNameCharacters(String name) {
-        if (!name.matches("^[a-zA-Z]*$")) {
+        if (!name.matches(NAME_REGEX_PATTERN)) {
             throw new IllegalArgumentException("자동차의 이름은 영어로만 이루어져야 합니다.");
         }
     }

--- a/src/main/java/racingcar/utils/InputValidator.java
+++ b/src/main/java/racingcar/utils/InputValidator.java
@@ -3,6 +3,9 @@ package racingcar.utils;
 import java.util.List;
 
 public class InputValidator {
+    private InputValidator() {
+    }
+
     public static void validateCarName(List<String> names) {
         validateDuplicateNames(names);
         for (String name : names) {

--- a/src/main/java/racingcar/utils/NameParser.java
+++ b/src/main/java/racingcar/utils/NameParser.java
@@ -6,6 +6,9 @@ import java.util.List;
 public class NameParser {
     private static final String DELIMITER = ",";
 
+    private NameParser() {
+    }
+
     public static List<String> parse(String rawNames) {
         String[] names = rawNames.split(DELIMITER);
         return Arrays.stream(names)

--- a/src/main/java/racingcar/utils/RandomNumberGenerator.java
+++ b/src/main/java/racingcar/utils/RandomNumberGenerator.java
@@ -5,6 +5,9 @@ import java.util.Random;
 public class RandomNumberGenerator {
     private static final int RANDOM_BOUND = 10;
 
+    private RandomNumberGenerator() {
+    }
+
     public static int generate() {
         Random random = new Random();
         return random.nextInt(RANDOM_BOUND);

--- a/src/main/java/racingcar/view/InputView.java
+++ b/src/main/java/racingcar/view/InputView.java
@@ -10,6 +10,10 @@ public class InputView {
 
     private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
+    // 인스턴스화 방지
+    private InputView() {
+    }
+
     public static String inputNames() throws IOException {
         System.out.println(NAME_INPUT_DESCRIPTION);
         return br.readLine();

--- a/src/main/java/racingcar/view/InputView.java
+++ b/src/main/java/racingcar/view/InputView.java
@@ -5,13 +5,18 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 public class InputView {
+    private static final String NAME_INPUT_DESCRIPTION = "경주할 자동차 이름을 입력하세요(이름은 쉼표(,)를 기준으로 구분).";
+    private static final String MOVE_COUNT_INPUT_DESCRIPTION = "시도할 회수는 몇회인가요?";
+
     private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
     public static String inputNames() throws IOException {
+        System.out.println(NAME_INPUT_DESCRIPTION);
         return br.readLine();
     }
 
     public static int inputMoveCount() throws IOException {
+        System.out.println(MOVE_COUNT_INPUT_DESCRIPTION);
         String moveCount = br.readLine();
         return Integer.parseInt(moveCount);
     }

--- a/src/main/java/racingcar/view/OutputView.java
+++ b/src/main/java/racingcar/view/OutputView.java
@@ -7,8 +7,6 @@ public class OutputView {
     private static final String WINNER_DESCRIPTION = "가 최종 우승했습니다.";
     private static final String RESULT_DESCRIPTION = "실행 결과";
     private static final String NO_WINNER_DESCRIPTION = "최대 이동 거리가 0이므로 우승한 자동차가 없습니다.";
-    private static final String NAME_INPUT_DESCRIPTION = "경주할 자동차 이름을 입력하세요(이름은 쉼표(,)를 기준으로 구분).";
-    private static final String MOVE_COUNT_INPUT_DESCRIPTION = "시도할 회수는 몇회인가요?";
     private static final String POSITION_METER = "-";
     private static final String CAR_NAME_DELIMITER = ",";
     private static final String NEW_LINE = System.lineSeparator();
@@ -45,13 +43,5 @@ public class OutputView {
 
     public static void printNoWinner() {
         System.out.println(NO_WINNER_DESCRIPTION);
-    }
-
-    public static void printlnInputName() {
-        System.out.println(NAME_INPUT_DESCRIPTION);
-    }
-
-    public static void printlnInputMoveCount() {
-        System.out.println(MOVE_COUNT_INPUT_DESCRIPTION);
     }
 }

--- a/src/main/java/racingcar/view/OutputView.java
+++ b/src/main/java/racingcar/view/OutputView.java
@@ -11,6 +11,10 @@ public class OutputView {
     private static final String CAR_NAME_DELIMITER = ",";
     private static final String NEW_LINE = System.lineSeparator();
 
+    // 인스턴스화 방지
+    private OutputView() {
+    }
+
     public static void printResultDescription() {
         System.out.println();
         System.out.println(RESULT_DESCRIPTION);

--- a/src/main/java/racingcar/view/OutputView.java
+++ b/src/main/java/racingcar/view/OutputView.java
@@ -9,8 +9,8 @@ public class OutputView {
     private static final String NO_WINNER_DESCRIPTION = "최대 이동 거리가 0이므로 우승한 자동차가 없습니다.";
     private static final String NAME_INPUT_DESCRIPTION = "경주할 자동차 이름을 입력하세요(이름은 쉼표(,)를 기준으로 구분).";
     private static final String MOVE_COUNT_INPUT_DESCRIPTION = "시도할 회수는 몇회인가요?";
-
     private static final String POSITION_METER = "-";
+    private static final String CAR_NAME_DELIMITER = ",";
     private static final String NEW_LINE = System.lineSeparator();
 
     public static void printResultDescription() {
@@ -38,10 +38,8 @@ public class OutputView {
     }
 
     public static void printWinnerList(List<String> winners) {
-        List<String> names = winners.stream()
-                .toList();
-
-        String winnerNames = String.join(", ", names);
+        List<String> names = winners.stream().toList();
+        String winnerNames = String.join(CAR_NAME_DELIMITER, names);
         System.out.println(winnerNames + WINNER_DESCRIPTION);
     }
 

--- a/src/main/java/racingcar/view/OutputView.java
+++ b/src/main/java/racingcar/view/OutputView.java
@@ -11,18 +11,26 @@ public class OutputView {
     private static final String MOVE_COUNT_INPUT_DESCRIPTION = "시도할 회수는 몇회인가요?";
 
     private static final String POSITION_METER = "-";
+    private static final String NEW_LINE = System.lineSeparator();
 
     public static void printResultDescription() {
         System.out.println();
         System.out.println(RESULT_DESCRIPTION);
     }
 
-    public static void printPosition(Map<String, Integer> carPositions) {
+    private static String createRoundResponseMessage(Map<String, Integer> roundResponse) {
         StringBuilder sb = new StringBuilder();
-        carPositions.forEach(
-                (name, position) -> sb.append(name).append(":").append(POSITION_METER.repeat(position)).append("\n")
+        roundResponse.forEach(
+                (name, position) -> sb.append(name).append(":").append(POSITION_METER.repeat(position)).append(NEW_LINE)
         );
-        System.out.println(sb);
+        sb.append(NEW_LINE);
+        return sb.toString();
+    }
+
+    public static void printPosition(List<Map<String, Integer>> raceResponse) {
+        StringBuilder sb = new StringBuilder();
+        raceResponse.forEach(r -> sb.append(createRoundResponseMessage(r)));
+        System.out.print(sb);
     }
 
     public static void printException(String message) {

--- a/src/test/java/racingcar/model/CarGroupTest.java
+++ b/src/test/java/racingcar/model/CarGroupTest.java
@@ -32,7 +32,7 @@ public class CarGroupTest {
         neo.move(moveNumber);
         pedro.move(moveNumber);
 
-        assertThat(carGroup.findWinners()).isEqualTo(List.of(neo));
+        assertThat(carGroup.findWinners()).isEqualTo(List.of("네오"));
     }
 
     @Test

--- a/src/test/java/racingcar/model/CarTest.java
+++ b/src/test/java/racingcar/model/CarTest.java
@@ -21,7 +21,7 @@ public class CarTest {
     @DisplayName("생성된 난수가 이동 기준을 만족하지 않을 때 위치는 변하지 않는다.")
     void notMoveTest() {
         final Car car = new Car("몰리");
-        final int randomNumber = 2;
+        final int randomNumber = 3;
 
         car.move(randomNumber);
 


### PR DESCRIPTION
안녕하세요 아서! 주말인데 빠르고 자세한 피드백 감사했어요.

말씀하셨던 부분들 반영해서 2단계 PR을 작성합니다.
2단계 미션에서는 'MVC 구조로의 리팩토링'이 주제였는데, 1단계 미션 진행 당시 MVC 구조를 채택하였어서 큰 구조 변경 없이 제출해요. 첫 리뷰에서 언급하셨던 '출력을 담당하는 클래스가 도메인을 알아야 할까?' 에 대한 부분은 1단계에서 수정 완료하여 이미 머지된 상태입니다!

변수/메서드명 변경이나 상수 포장 등을 제외하면, 주요 변경점은 다음 두 가지로 정리할 수 있을 것 같아요.

### 입력 재 시도 로직 구현의 변경
기존 구현에서 메서드명이 게터와 혼동되거나 메서드의 역할을 정확히 드러내지 못하는 문제가 있었고, 재 시도를 위한 플래그 변수의 이름 역시 모호했었는데요.
> 플래그 값이 왜 필요했는지 한번 고민해보시면 좋을 것 같아요.
혹시 메서드가 두가지 기능을 하고 있지는 않나요?
현재 단순히 이름을 읽어오는 역할만 하고 있나요?

이 말에서 힌트를 얻어 반복 구조를 바꾸고 플래그 변수를 제거해 보았습니다.
다만, 일반적으로 잘 사용하지 않았던 `do~while` 구문으로 반복을 구현했는데, 이것에 대한 아서의 생각은 어떤지 궁금해요. 지양해야 하는 부분일까요? 아니면 사용했을 때의 코드가 좀 더 읽기 편해진다면 걱정 없이 사용해도 되는 걸까요?

### `RacingGame` 클래스의 추가
입력 재 시도 로직을 변경하면서 '입력받은 이름과 이동 횟수를 과연 컨트롤러의 필드로 가지고 있어야 하는가?' 에 대한 고민이 있었습니다. 필드에 저장해 두었던 이유를 생각해 보니 입력받는 메서드와 레이싱 라운드를 반복해 주는 라운드가 분리되어 있어, 값 참조를 위한 저장 그 이상도 이하도 아니더라구요.  
이런 이유라면 차라리 `자동차 그룹`과 `라운드 진행 횟수`를 가지는 `RacingGame` 객체를 도입하고, 컨트롤러에서는 `RacingGame`에 `.race()` 명령만 내린 후 결과를 받아와 뷰에 전달하는 역할만 수행하는 것이 좀 더 깔끔하겠다는 생각이 들어 해당 구조로 변경했습니다.

결과적으로 `CarGroup`은 `Car`의 리스트를 래핑한 일급 컬렉션으로서, 승자를 찾고 `한 라운드`를 진행하는 책임을 갖게 됩니다. 반면 `RacingGame`은 자신의 `moveCount`를 참조하여 `CarGroup`에게 해당 횟수만큼 라운드를 반복하게 하는 역할을 하구요.
컨트롤러에서는 `RacingGame`을 사용하기에 `RacingGame.findWinners()`는 단순히 `CarGroup.findWinners()`를 반환하도록 되어 있습니다.

```java
public List<String> findWinners() {
    return cars.findWinners();
}
```
단순히 점프를 띄워 주는(?) 이러한 구현에 문제가 없을지 궁금하고, 이 경우 `RacingGame`에서 테스트할 수 있는 것은 "반복문이 잘 돌아가는가?" 와 "carGroup.findWinners() 가 잘 호출되고 반환되는가?" 정도 밖에 없을 것 같아 해당 클래스에 대한 테스트 코드는 작성하지 않았는데, 아서의 생각은 어떤지 궁금합니다!